### PR TITLE
fix: incorrect format of heroku.yml

### DIFF
--- a/heroku.yml
+++ b/heroku.yml
@@ -1,7 +1,5 @@
 build:
   docker:
     worker: Dockerfile
-release:
-  image: worker
-  command:
-    - python3 ./CloneCord-Mac-Linux.py
+run:
+  worker: python3 ./CloneCord-Mac-Linux.py


### PR DESCRIPTION
Switched to use "run" instead of "release".

Refer to https://devcenter.heroku.com/articles/build-docker-images-heroku-yml#run-defining-the-processes-to-run